### PR TITLE
Convert db time to korean time

### DIFF
--- a/app/api/resource_usage.py
+++ b/app/api/resource_usage.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from typing import Dict, Any, List, Tuple
 import asyncio
 from datetime import datetime
+from app.utils.time import now_kst
 import json
 
 from app.database.database import get_db
@@ -100,7 +101,7 @@ async def collect_resource_usage(payload: CollectRequest, db: Session = Depends(
                 ftp=metrics.get("ftp"),
                 community=payload.community,
                 oids_raw=json.dumps(payload.oids),
-                collected_at=datetime.utcnow(),
+                collected_at=now_kst(),
             )
             db.add(model)
             collected_models.append(model)

--- a/app/api/session_browser.py
+++ b/app/api/session_browser.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Tuple
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from app.utils.time import now_kst, KST_TZ
 import re
 import warnings
 try:
@@ -104,7 +105,7 @@ def _parse_sessions(output: str) -> List[Dict[str, Any]]:
         if creation_time_idx is not None:
             ct = parts[creation_time_idx]
             try:
-                creation_time = datetime.strptime(ct, "%Y-%m-%d %H:%M:%S")
+                creation_time = datetime.strptime(ct, "%Y-%m-%d %H:%M:%S").replace(tzinfo=KST_TZ)
             except Exception:
                 creation_time = None
 
@@ -266,7 +267,7 @@ async def collect_sessions(payload: CollectRequest, db: Session = Depends(get_db
                         in_use=rec.get("in_use"),
                         url=rec.get("url"),
                         raw_line=rec.get("raw_line"),
-                        collected_at=datetime.utcnow(),
+                        collected_at=now_kst(),
                     )
                     db.add(model)
                     collected_models.append(model)

--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
 from app.database.database import Base
+from app.utils.time import now_kst
 
 class Proxy(Base):
     __tablename__ = "proxies"
@@ -14,8 +14,8 @@ class Proxy(Base):
     is_active = Column(Boolean, default=True)
     group_id = Column(Integer, ForeignKey("proxy_groups.id", ondelete="SET NULL"), nullable=True)
     description = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    created_at = Column(DateTime(timezone=True), default=now_kst)
+    updated_at = Column(DateTime(timezone=True), onupdate=now_kst, default=now_kst)
 
     group = relationship("ProxyGroup", backref="proxies")
 

--- a/app/models/proxy_group.py
+++ b/app/models/proxy_group.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, Text
-from sqlalchemy.sql import func
 from app.database.database import Base
+from app.utils.time import now_kst
 
 class ProxyGroup(Base):
     __tablename__ = "proxy_groups"
@@ -8,8 +8,8 @@ class ProxyGroup(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    created_at = Column(DateTime(timezone=True), default=now_kst)
+    updated_at = Column(DateTime(timezone=True), onupdate=now_kst, default=now_kst)
 
     @property
     def proxies_count(self) -> int:

--- a/app/models/resource_config.py
+++ b/app/models/resource_config.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, Text, DateTime
-from sqlalchemy.sql import func
 from app.database.database import Base
+from app.utils.time import now_kst
 
 
 class ResourceConfig(Base):
@@ -9,6 +9,6 @@ class ResourceConfig(Base):
     id = Column(Integer, primary_key=True, index=True)
     community = Column(String, nullable=False, default="public")
     oids_json = Column(Text, nullable=False, default='{}')  # json string mapping
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    created_at = Column(DateTime(timezone=True), default=now_kst)
+    updated_at = Column(DateTime(timezone=True), onupdate=now_kst, default=now_kst)
 

--- a/app/models/resource_usage.py
+++ b/app/models/resource_usage.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Float, Text
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
 from app.database.database import Base
+from app.utils.time import now_kst
 
 
 class ResourceUsage(Base):
@@ -23,9 +23,9 @@ class ResourceUsage(Base):
     community = Column(String, nullable=True)
     oids_raw = Column(Text, nullable=True)  # json string of oid mapping used for collection
 
-    collected_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    collected_at = Column(DateTime(timezone=True), default=now_kst, index=True)
+    created_at = Column(DateTime(timezone=True), default=now_kst)
+    updated_at = Column(DateTime(timezone=True), onupdate=now_kst, default=now_kst)
 
     proxy = relationship("Proxy", backref="resource_usages")
 

--- a/app/models/session_browser_config.py
+++ b/app/models/session_browser_config.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime
-from sqlalchemy.sql import func
 from app.database.database import Base
+from app.utils.time import now_kst
 
 
 class SessionBrowserConfig(Base):
@@ -14,6 +14,6 @@ class SessionBrowserConfig(Base):
     host_key_policy = Column(String, nullable=False, default="auto_add")  # auto_add | reject
     max_workers = Column(Integer, nullable=False, default=4)
 
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    created_at = Column(DateTime(timezone=True), default=now_kst)
+    updated_at = Column(DateTime(timezone=True), onupdate=now_kst, default=now_kst)
 

--- a/app/models/session_record.py
+++ b/app/models/session_record.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, Index
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
 from app.database.database import Base
+from app.utils.time import now_kst
 
 
 class SessionRecord(Base):
@@ -38,9 +38,9 @@ class SessionRecord(Base):
     # Raw line for debug/troubleshooting
     raw_line = Column(Text, nullable=True)
 
-    collected_at = Column(DateTime(timezone=True), server_default=func.now())
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    collected_at = Column(DateTime(timezone=True), default=now_kst)
+    created_at = Column(DateTime(timezone=True), default=now_kst)
+    updated_at = Column(DateTime(timezone=True), onupdate=now_kst, default=now_kst)
 
     proxy = relationship("Proxy", backref="session_records")
 

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timezone, timedelta
+
+try:
+    from zoneinfo import ZoneInfo
+except Exception:
+    ZoneInfo = None  # type: ignore
+
+
+# Exported timezone object for Asia/Seoul (KST, UTC+9)
+KST_TZ = None
+try:
+    if ZoneInfo is not None:
+        KST_TZ = ZoneInfo("Asia/Seoul")
+except Exception:
+    KST_TZ = None
+
+if KST_TZ is None:
+    # Fallback to fixed UTC+9 offset if IANA tz data is unavailable
+    KST_TZ = timezone(timedelta(hours=9))
+
+
+def now_kst() -> datetime:
+    """Return current datetime in Asia/Seoul timezone (timezone-aware)."""
+    try:
+        if ZoneInfo is not None:
+            return datetime.now(ZoneInfo("Asia/Seoul"))
+    except Exception:
+        pass
+    return datetime.now(timezone(timedelta(hours=9)))
+


### PR DESCRIPTION
Store all new database timestamps and API-generated timestamps in Korean Standard Time (KST, GMT+9).

---
<a href="https://cursor.com/background-agent?bcId=bc-87b0cb91-73ca-47bf-964e-961c56f2aaab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87b0cb91-73ca-47bf-964e-961c56f2aaab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

