### PR TITLE
Heatmap 테이블로 자원 사용률 가시성 개선

### DIFF
--- a/app/static/theme/theme.css
+++ b/app/static/theme/theme.css
@@ -371,6 +371,11 @@ body {
 /* Session browser: prevent wrapping in created-at column (2nd column) */
 #sbTable td:nth-child(2), #sbTable th:nth-child(2) { white-space: nowrap; }
 .dt-nowrap { white-space: nowrap; }
+.ru-heat-row td { padding: 0.25rem; }
+#ruHeatTable { table-layout: fixed; }
+#ruHeatTable th, #ruHeatTable td { white-space: nowrap; }
+.ru-heat-proxy { position: sticky; left: 0; background: var(--color-surface); z-index: 1; }
+.ru-heat-cell { width: 100%; height: 28px; display: flex; align-items: center; justify-content: center; border-radius: 4px; border: 1px solid rgba(0,0,0,0.05); font-size: 0.9rem; }
 
 /* Footer: align background with page background */
 .footer {

--- a/app/templates/components/resource_usage.html
+++ b/app/templates/components/resource_usage.html
@@ -82,11 +82,10 @@
 
     <div class="mt-4">
         <div class="table-container" id="ruTableWrap">
-            <table class="table is-fullwidth is-striped is-hoverable">
+            <table class="table is-fullwidth is-striped is-hoverable" id="ruHeatTable">
                 <thead>
                     <tr>
                         <th>프록시</th>
-                        <th>수집시각</th>
                         <th>CPU</th>
                         <th>MEM</th>
                         <th>CC</th>


### PR DESCRIPTION
Convert resource usage table to a heatmap-style grid to improve visibility and readability for many proxies.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf3e23ed-47f6-464e-bfc9-49f740d069db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf3e23ed-47f6-464e-bfc9-49f740d069db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

