### PR TITLE
Remove unused session browser header filter

### DIFF
--- a/app/static/js/session_browser.js
+++ b/app/static/js/session_browser.js
@@ -174,15 +174,7 @@ $(document).ready(function() {
                     { targets: 1, className: 'dt-nowrap' },
                     { targets: 8, className: 'dt-nowrap dt-ellipsis', width: '480px' }
                 ],
-                createdRow: function(row, data) { $(row).attr('data-item-id', data[data.length - 1]); },
-                initComplete: function(){
-                    try{
-                        var api = this.api ? this.api() : (sb.dt && sb.dt.columns ? sb.dt : null);
-                        if(!api || !(api.columnControl && api['columnControl.bind'])) return;
-                        // Skip hidden id(last col)
-                        api['columnControl.bind']({ skipColumns: [api.columns().count() - 1] });
-                    }catch(e){ /* ignore */ }
-                }
+                createdRow: function(row, data) { $(row).attr('data-item-id', data[data.length - 1]); }
             });
             setTimeout(function(){ TableConfig.adjustColumns(sb.dt); }, 0);
         } catch (e) {

--- a/app/templates/components/session_browser.html
+++ b/app/templates/components/session_browser.html
@@ -97,9 +97,7 @@
 
 <!-- DataTables (local) -->
 <link rel="stylesheet" href="/static/vendor/datatables/datatables.min.css?v={{ request.app.version }}">
-<link rel="stylesheet" href="/static/vendor/datatables/columnControl/columnControl.dataTables.min.css?v={{ request.app.version }}">
 <script src="/static/vendor/datatables/datatables.min.js?v={{ request.app.version }}"></script>
-<script src="/static/vendor/datatables/columnControl/dataTables.columnControl.min.js?v={{ request.app.version }}"></script>
 
  
 


### PR DESCRIPTION
Remove unused and improperly implemented ColumnControl header filter from the Session Browser.

---
<a href="https://cursor.com/background-agent?bcId=bc-20b5e53c-92c3-408b-9b0b-e420f1b513c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20b5e53c-92c3-408b-9b0b-e420f1b513c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

